### PR TITLE
Fix FTP related build failure

### DIFF
--- a/src/Data/SplayTree.hs
+++ b/src/Data/SplayTree.hs
@@ -43,7 +43,7 @@ import Control.Monad
 import Control.DeepSeq
 
 import Data.Data
-import Data.Foldable
+import Data.Foldable hiding (null)
 import Data.Maybe
 import Data.Monoid
 

--- a/src/Data/SplayTree/RangeSet.hs
+++ b/src/Data/SplayTree/RangeSet.hs
@@ -32,7 +32,7 @@ import qualified Data.SplayTree as S
 
 import Control.Applicative hiding (empty)
 import Data.Monoid
-import Data.Foldable
+import Data.Foldable hiding (null)
 import Data.Traversable
 
 -- | a RangeSet element

--- a/src/Data/SplayTree/Seq.hs
+++ b/src/Data/SplayTree/Seq.hs
@@ -24,7 +24,7 @@ import qualified Data.SplayTree as S
 
 import Control.Applicative hiding (empty)
 import Data.Monoid
-import Data.Foldable
+import Data.Foldable hiding (length)
 import Data.Traversable
 
 -- a Seq type

--- a/src/Data/SplayTree/Set.hs
+++ b/src/Data/SplayTree/Set.hs
@@ -31,7 +31,7 @@ import qualified Data.SplayTree as S
 import           Control.Applicative hiding (empty)
 import           Data.Maybe
 import           Data.Monoid
-import           Data.Foldable
+import           Data.Foldable hiding (null)
 import           Data.Traversable
 
 -- a Set type


### PR DESCRIPTION
Data.Foldable now exports null and length, lets hide them

With older `base` it now emits a warning, but the code is not warning-free anyway.
